### PR TITLE
Include groovy classes in -sources jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,25 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>add-groovy-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/src/main/groovy</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.11</version>


### PR DESCRIPTION
The latest releases of the the project (`1.0.0` and `1.1.0`) do not include the various Groovy classes in their `-sources` jars. They were included in prior releases (I checked `0.18.7`). I've used the `build-helper-maven-plugin` to add `src/main/groovy` as an additional source directory so that these classes will be included.
