### PR TITLE
Added support for warmers.

### DIFF
--- a/src/main/groovy/org/elasticsearch/groovy/client/GIndicesAdminClient.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/GIndicesAdminClient.groovy
@@ -66,6 +66,7 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequestBuilder
 import org.elasticsearch.action.admin.indices.status.IndicesStatusRequestBuilder
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequestBuilder
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder
+import org.elasticsearch.action.admin.indices.warmer.put.PutWarmerRequestBuilder
 import org.elasticsearch.client.internal.InternalClient
 import org.elasticsearch.groovy.client.action.GActionFuture
 import org.elasticsearch.groovy.common.xcontent.GXContentBuilder
@@ -479,5 +480,10 @@ class GIndicesAdminClient {
         GActionFuture<DeleteIndexTemplateResponse> future = new GActionFuture<DeleteIndexTemplateResponse>(internalClient.threadPool(), request)
         indicesAdminClient.deleteTemplate(request, future)
         return future
+    }
+
+
+    PutWarmerRequestBuilder preparePutWarmer(String name){
+        indicesAdminClient.preparePutWarmer(name)
     }
 }


### PR DESCRIPTION
Now we can do:
gclientInstance.admin.indices.preparePutWarmer(warmerName)

Where as before we had to grope GClient to get an explicit handle of
client:

gClientInstance.client.admin().indices().preparPutWarmer(warmerName).

Having the preparePutWarmer wrapper makes the api more consistent with the rest of the Groovy API.
