### PR TITLE
Support groovydocs in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,37 @@
                             <goal>run</goal>
                         </goals>
                     </execution>
+                    <execution>
+                      <id>groovydoc</id>
+                      <phase>site</phase>
+                      <goals>
+                        <goal>run</goal>
+                      </goals>
+                      <configuration>
+                        <target>
+                          <taskdef name="groovydoc"
+                            classname="org.codehaus.groovy.ant.Groovydoc" 
+                            classpathref="maven.compile.classpath"
+                          />
+                          <groovydoc destdir="${project.reporting.outputDirectory}/groovydoc"
+                            sourcepath="${basedir}/src/main/groovy" use="true"
+                            windowtitle="${project.name}"
+                            doctitle="${project.name}"
+                          >
+                            <link packages="java.,org.xml.,javax.,org.xml."
+                              href="http://download.oracle.com/javase/6/docs/api" />
+                            <link packages="org.apache.tools.ant." 
+                              href="http://evgeny-goldin.org/javadoc/ant/api" />
+                            <link packages="org.junit.,junit.framework."
+                              href="http://kentbeck.github.com/junit/javadoc/latest" />
+                            <link packages="groovy.,org.codehaus.groovy."
+                              href="http://groovy.codehaus.org/api/" />
+                            <link packages="org.codehaus.gmaven."
+                              href="http://evgeny-goldin.org/javadoc/gmaven" />
+                          </groovydoc>
+                        </target>
+                      </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,44 @@
 
     <build>
         <plugins>
+	    <plugin>
+  		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-antrun-plugin</artifactId>
+  		<version>1.7</version>
+  		<executions>
+    			<execution>
+      				<id>groovydoc</id>
+      				<phase>site</phase>
+      				<goals>
+        				<goal>run</goal>
+      				</goals>
+      			<configuration>
+        		<target>
+          			<taskdef name="groovydoc"
+            				classname="org.codehaus.groovy.ant.Groovydoc" 
+            				classpathref="maven.compile.classpath"
+          			/>
+          		<groovydoc destdir="${project.reporting.outputDirectory}/groovydoc"
+            			sourcepath="${basedir}/src/main/groovy" use="true"
+            			windowtitle="${project.name}"
+            			doctitle="${project.name}"
+          		>
+            		<link packages="java.,org.xml.,javax.,org.xml."
+              			href="http://download.oracle.com/javase/6/docs/api" />
+            		<link packages="org.apache.tools.ant." 
+              			href="http://evgeny-goldin.org/javadoc/ant/api" />
+            		<link packages="org.junit.,junit.framework."
+              			href="http://kentbeck.github.com/junit/javadoc/latest" />
+            		<link packages="groovy.,org.codehaus.groovy."
+              			href="http://groovy.codehaus.org/api/" />
+            		<link packages="org.codehaus.gmaven."
+             			href="http://evgeny-goldin.org/javadoc/gmaven" />
+          		</groovydoc>
+        		</target>
+      			</configuration>
+    			</execution>
+  		</executions>
+	  </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -209,37 +247,6 @@
                         <goals>
                             <goal>run</goal>
                         </goals>
-                    </execution>
-                    <execution>
-                      <id>groovydoc</id>
-                      <phase>site</phase>
-                      <goals>
-                        <goal>run</goal>
-                      </goals>
-                      <configuration>
-                        <target>
-                          <taskdef name="groovydoc"
-                            classname="org.codehaus.groovy.ant.Groovydoc" 
-                            classpathref="maven.compile.classpath"
-                          />
-                          <groovydoc destdir="${project.reporting.outputDirectory}/groovydoc"
-                            sourcepath="${basedir}/src/main/groovy" use="true"
-                            windowtitle="${project.name}"
-                            doctitle="${project.name}"
-                          >
-                            <link packages="java.,org.xml.,javax.,org.xml."
-                              href="http://download.oracle.com/javase/6/docs/api" />
-                            <link packages="org.apache.tools.ant." 
-                              href="http://evgeny-goldin.org/javadoc/ant/api" />
-                            <link packages="org.junit.,junit.framework."
-                              href="http://kentbeck.github.com/junit/javadoc/latest" />
-                            <link packages="groovy.,org.codehaus.groovy."
-                              href="http://groovy.codehaus.org/api/" />
-                            <link packages="org.codehaus.gmaven."
-                              href="http://evgeny-goldin.org/javadoc/gmaven" />
-                          </groovydoc>
-                        </target>
-                      </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
We've added an automated build of the groovydoc for our own purposes, available here:

http://elasticsearch.spantree.net/elasticsearch-lang-groovy/HEAD

In order to get this to work, we had to add a new antrun goal. Ideally, this should be in mainline in case anyone else wants to generate the groovydocs as part of their builds.
