### PR TITLE
Added prepareUpdate to GClient

### DIFF
--- a/src/main/groovy/org/elasticsearch/groovy/client/GClient.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/GClient.groovy
@@ -351,6 +351,10 @@ class GClient {
         return future
     }
 
+    UpdateRequestBuilder prepareUpdate(String index, String type, String id) {
+        client.prepareUpdate(index, type, id)
+    }
+
     void moreLikeThis(MoreLikeThisRequest request, ActionListener<SearchResponse> listener) {
         client.moreLikeThis(request, listener)
     }


### PR DESCRIPTION
It is now possible to do gClientInstance.prepareUpdate(), instead of gClientInstance.client.prepareUpdate().
